### PR TITLE
Update publisher name in package.json to reflect current maintainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "ai": "^4.2.0",
     "aws-sdk": "^2.1692.0"
   },
-  "publisher": "your-publisher-name",
+  "publisher": "gyaneshgouraw",
   "repository": {
     "type": "git",
     "url": "https://github.com/your-username/git-ai-assistant.git"


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file, where the `publisher` field has been updated to reflect the correct publisher name.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L208-R208): Changed the `publisher` field from `"your-publisher-name"` to `"gyaneshgouraw"`.